### PR TITLE
Update gettingstarted.rst

### DIFF
--- a/docs/source/guide/gettingstarted.rst
+++ b/docs/source/guide/gettingstarted.rst
@@ -22,17 +22,17 @@ Let's get the Compound with `CID 5090`_::
 Now we have a :class:`~pubchempy.Compound` object called ``c``. We can get all the information we need from this
 object::
 
-    >>> print c.molecular_formula
+    >>> print(c.molecular_formula)
     C17H14O4S
-    >>> print c.molecular_weight
-    314.35566
-    >>> print c.isomeric_smiles
+    >>> print(c.molecular_weight)
+    314.4
+    >>> print(c.isomeric_smiles)
     CS(=O)(=O)C1=CC=C(C=C1)C2=C(C(=O)OC2)C3=CC=CC=C3
-    >>> print c.xlogp
+    >>> print(c.xlogp)
     2.3
-    >>> print c.iupac_name
+    >>> print(c.iupac_name)
     3-(4-methylsulfonylphenyl)-4-phenyl-2H-furan-5-one
-    >>> print c.synonyms
+    >>> print(c.synonyms)
     [u'rofecoxib', u'Vioxx', u'Ceoxx', u'162011-90-7', u'MK 966', ... ]
 
 .. note::
@@ -51,19 +51,16 @@ What if you don't know the PubChem CID of the Compound you want? Just use the :f
 function::
 
     >>> results = pcp.get_compounds('Glucose', 'name')
-    >>> print results
-    [Compound(79025), Compound(5793), Compound(64689), Compound(206)]
+    >>> print(results)
+    [Compound(5793)]
 
 The first argument is the identifier, and the second argument is the identifier type, which must be one of ``name``,
 ``smiles``, ``sdf``, ``inchi``, ``inchikey`` or ``formula``. It looks like there are 4 compounds in the PubChem
 Database that have the name Glucose associated with them. Let's take a look at them in more detail::
 
     >>> for compound in results:
-    ...    print compound.isomeric_smiles
-    C([C@@H]1[C@H]([C@@H]([C@H]([C@H](O1)O)O)O)O)O
+    ...    print(compound.isomeric_smiles)
     C([C@@H]1[C@H]([C@@H]([C@H](C(O1)O)O)O)O)O
-    C([C@@H]1[C@H]([C@@H]([C@H]([C@@H](O1)O)O)O)O)O
-    C(C1C(C(C(C(O1)O)O)O)O)O
 
 It looks like they all have different stereochemistry information.
 


### PR DESCRIPTION
Re-run the instructions with PubChemPy (version 1.0.4) in Python 3.9.2, gentle revision.

Beside the more obvious change about `print foo` to `print(foo)`,  the PubChem database
apparently underwent some consolidation.  As a result some resulting lists do not contain
any more this many entries as in the elder documentation; perhaps with the exception of
synonyms known to the database.